### PR TITLE
Updates to JAR3D results table

### DIFF
--- a/Templates/JAR3Doutput/base_result_done.html
+++ b/Templates/JAR3Doutput/base_result_done.html
@@ -36,7 +36,7 @@
       <thead>
         <tr>
           <th class='table-header' data-header-name='index'>#</th>
-          <th class='table-header' data-header-name='motif' style='min-width:200px'>Motif ID and Additional Information</th>
+          <th class='table-header' data-header-name='motif' style='min-width:200px'>Matching motif</th>
           <th class='table-header' data-header-name='percent'>Acceptance Rate</th>
           <th class='table-header' data-header-name='mean-score'>Mean Cutoff Score</th>
           <th class='table-header' data-header-name='full-edit'>Full Edit Distance</th>

--- a/Templates/JAR3Doutput/base_result_done.html
+++ b/Templates/JAR3Doutput/base_result_done.html
@@ -49,14 +49,19 @@
       <tr>
         <td>{{ forloop.counter }}</td>
         <td class="hover-link">
-          <input type='radio' name="group" id='s{{ forloop.parentloop.counter }}-{{ forloop.counter }}'
-                 class='jmolInline' data-coord='{{ result.motif_id }}'>
-          <label for='s{{ forloop.parentloop.counter }}-{{ forloop.counter }}'>{{ result.motif_id }}</label>
-          View <a href="{{ result.motif_url }}" target="_blank">{{ result.motif_id }}</a>
-
-          <br>{{result.signature}}<br>
-
-        <a class='btn btn-default' href="{{result.align_url}}{{result.motif_id}}" target="_blank">Align sequences</a>
+          <p>
+            <strong>Motif <a href="{{ result.motif_url }}" target="_blank">{{ result.motif_id }}</a></strong>
+          </p>
+          <p>
+            Basepair signature: {{result.signature}}
+          </p>
+          <p>
+            <input type='radio' name="group" id='s{{ forloop.parentloop.counter }}-{{ forloop.counter }}'
+                   class='jmolInline' data-coord='{{ result.motif_id }}'>
+            <label for='s{{ forloop.parentloop.counter }}-{{ forloop.counter }}'>View motif example in 3D</label>
+            <br>
+            <a class='btn btn-default' href="{{result.align_url}}{{result.motif_id}}" target="_blank">Align sequences</a>
+          </p>
         </td>
         <td>{{ result.cutoff_percent|floatformat:2 }}</td>
         <td>{{ result.mean_cutoff_score|floatformat:2 }}</td>

--- a/Templates/JAR3Doutput/base_result_done.html
+++ b/Templates/JAR3Doutput/base_result_done.html
@@ -36,7 +36,7 @@
       <thead>
         <tr>
           <th class='table-header' data-header-name='index'>#</th>
-          <th class='table-header' data-header-name='motif'>Motif ID and Additional Information</th>
+          <th class='table-header' data-header-name='motif' style='min-width:200px'>Motif ID and Additional Information</th>
           <th class='table-header' data-header-name='percent'>Acceptance Rate</th>
           <th class='table-header' data-header-name='mean-score'>Mean Cutoff Score</th>
           <th class='table-header' data-header-name='full-edit'>Full Edit Distance</th>

--- a/Templates/JAR3Doutput/base_result_done.html
+++ b/Templates/JAR3Doutput/base_result_done.html
@@ -56,7 +56,7 @@
 
           <br>{{result.signature}}<br>
 
-        <a class='btn btn-primary' href="{{result.align_url}}{{result.motif_id}}" target="_blank">Align sequences</a>
+        <a class='btn btn-default' href="{{result.align_url}}{{result.motif_id}}" target="_blank">Align sequences</a>
         </td>
         <td>{{ result.cutoff_percent|floatformat:2 }}</td>
         <td>{{ result.mean_cutoff_score|floatformat:2 }}</td>


### PR DESCRIPTION
@blakesweeney, @jimroll, @clzirbel 

Here is a suggestion for a hopefully more organised way of showing motif matches:

![screen shot 2016-02-26 at 13 15 59](https://cloud.githubusercontent.com/assets/432675/13353563/2e02a24a-dc8d-11e5-86a2-308e567a202c.png)

Please see commit messages for more information about what was changed. Feel free to let me know if you have any feedback.
